### PR TITLE
JVM processes can freeze due to starved entropy

### DIFF
--- a/dependency-scan.sh
+++ b/dependency-scan.sh
@@ -3,6 +3,11 @@
 # MIT License - https://github.com/integralads/dependency-deep-scan-utilities/blob/master/README.md
 set -exo pipefail
 
+# https://stackoverflow.com/questions/58991966/what-java-security-egd-option-is-for
+export MAVEN_OPTS GRADLE_OPTS
+MAVEN_OPTS='-Djava.security.egd=file:/dev/./urandom'" ${MAVEN_OPTS:-}"
+GRADLE_OPTS='-Djava.security.egd=file:/dev/./urandom'" ${GRADLE_OPTS:-}"
+
 java_versions=(
   openjdk8
   openjdk11


### PR DESCRIPTION
Because this can heavily use parallelism with containers hardware entropy is a limited shared resource.  When all containers starve the system of entropy reading from `/dev/random` the JVM can hang until enough entropy is generated.  The workaround is to use `/dev/urandom` so that pseudo-randomness relies on generated entropy instead of hardware entropy.

The starvation causes a denial of service across all containers and has a net effect of all JVM processes hanging on FUTEX_WAIT system call.

Discovered by using strace and inspecting the proc filesystem open file handles.